### PR TITLE
Enable extra prometheus client metrics

### DIFF
--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -61,6 +61,9 @@ type Config struct {
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
 
+	// ReportExtraMetrics - enables reporting of additional metrics for Prometheus client like scrape_body_size_bytes
+	ReportExtraMetrics bool `mapstructure:"report_extra_metrics"`
+
 	TargetAllocator *targetAllocator `mapstructure:"target_allocator"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -50,6 +50,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, time.Duration(r1.PrometheusConfig.ScrapeConfigs[0].ScrapeInterval), 5*time.Second)
 	assert.Equal(t, r1.UseStartTimeMetric, true)
 	assert.Equal(t, r1.StartTimeMetricRegex, "^(.+_)*process_start_time_seconds$")
+	assert.True(t, r1.ReportExtraMetrics)
 
 	assert.Equal(t, "http://my-targetallocator-service", r1.TargetAllocator.Endpoint)
 	assert.Equal(t, 30*time.Second, r1.TargetAllocator.Interval)

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -227,7 +227,7 @@ func (r *pReceiver) initPrometheusComponents(ctx context.Context, host component
 		r.cfg.ID(),
 		r.cfg.PrometheusConfig.GlobalConfig.ExternalLabels,
 	)
-	r.scrapeManager = scrape.NewManager(&scrape.Options{PassMetadataInContext: true}, logger, store)
+	r.scrapeManager = scrape.NewManager(&scrape.Options{PassMetadataInContext: true, ExtraMetrics: r.cfg.ReportExtraMetrics}, logger, store)
 	go func() {
 		if err := r.scrapeManager.Run(r.discoveryManager.SyncCh()); err != nil {
 			r.settings.Logger.Error("Scrape manager failed", zap.Error(err))

--- a/receiver/prometheusreceiver/testdata/config.yaml
+++ b/receiver/prometheusreceiver/testdata/config.yaml
@@ -5,6 +5,7 @@ receivers:
     buffer_count: 45
     use_start_time_metric: true
     start_time_metric_regex: '^(.+_)*process_start_time_seconds$'
+    report_extra_metrics: true
     target_allocator:
       endpoint: http://my-targetallocator-service
       interval: 30s


### PR DESCRIPTION
Feature: Enable reporting of additional metrics for Prometheus client used in PrometheusReceiver

Description:
Prometheus client has a featureFlag options.ExtraMetrics which reports content size metric (scrape_body_size_bytes) for successful scrapes and -1 for dropped data. This metric will help us collect data and setup alert for dropped data. However the prometheus receiver does not have a way to enable this feature flag.

This PR passes the flag to scrape.NewManager() to enable reporting of metric - scrape_body_size_bytes

Link to tracking Issue:
#21040

Testing:
Added check for validating the value set in testdata/config.yaml